### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-pr-helper.yml
+++ b/.github/workflows/issue-pr-helper.yml
@@ -1,5 +1,9 @@
 name: Issue and PR Helper
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/pollypm/polly/security/code-scanning/8](https://github.com/pollypm/polly/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used (`actions/labeler`, `actions/first-interaction`, and `kentaro-m/auto-assign-action`), the workflow requires `contents: read` and `issues: write` permissions. These permissions allow the workflow to read repository contents and interact with issues and pull requests as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
